### PR TITLE
chore: update lefthook configuration and package scripts

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,18 +1,17 @@
 pre-commit:
   parallel: true
   commands:
-    exports:
-      run: npm run check-exports
+    types:
+      run: npm run typecheck
     test:
       run: npm test
+    tslint:
+      run: npm run tslint
     lint:
       glob: '*.{js,ts,jsx,tsx}' # glob filter for list of files
       run: npm run lint
     format:
       run: npm run format 
-    #types:
-      #glob: '*.{js,ts, jsx, tsx}'
-      #run: npm run typecheck
 pre-push:
   parallel: true
   commands:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A simple docs scraper",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ben-shepherd/simple-docs-scraper"
+    "url": "git+https://github.com/ben-shepherd/simple-docs-scraper.git"
   },
   "license": "ISC",
   "author": "ben.shepherd@gmx.com",
@@ -27,6 +27,7 @@
     "lint:fix": "eslint --fix --ignore-pattern .gitignore \"{src,tests}/**/*.+(ts|js|tsx)\"",
     "typecheck": "tsc --noEmit",
     "format": "prettier --ignore-path .prettierignore --write \"**/*.+(js|ts|json|tsx|mdx)\" --log-level silent",
+    "format:check": "prettier --ignore-path .prettierignore --check \"**/*.+(js|ts|json|tsx|mdx)\" --log-level silent",
     "check-exports": "node ./scripts/check-exports.js",
     "check": "npm run format && npm run lint:fix && npm run typecheck && npm run check-exports",
     "version:patch": "npm version patch",

--- a/src/scripts/publish-docs.ts
+++ b/src/scripts/publish-docs.ts
@@ -18,7 +18,7 @@ export const DEFAULT_CONFIG: SimpleDocsScraperConfig = {
             filesHeading: '\n## Files\n',
             directoryHeading: '\n## Folders\n',
             excerpt: {
-                length: 75,
+                length: 100,
                 addEllipsis: false,
                 firstSentenceOnly: true
             },


### PR DESCRIPTION
- Replace 'exports' command with 'types' for type checking in lefthook.
- Add 'format:check' script to package.json for checking formatting.
- Update repository URL in package.json to include .git extension.
- Adjust excerpt length in publish-docs script from 75 to 100.