### PR TITLE
feat: Locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation is available [here](docs/index.md).
 
 ```typescript
 import path from 'path';
-import { SimpleDocsScraper, MultiLineCommentClear } from '../../dist/index.js';
+import { SimpleDocExtractor, MultiLineCommentClear } from '../../dist/index.js';
 
 const config = {
     baseDir: process.cwd(),
@@ -48,7 +48,7 @@ const config = {
     formatters: [MultiLineCommentClear],
 };
 
-new SimpleDocsScraper(config).start().then(result => {
+new SimpleDocExtractor(config).start().then(result => {
     console.log('Success count: ', result.successCount);
     console.log('Total count: ', result.totalCount);
     console.log('Logs:');

--- a/docs/simple-docs-scraper/services/SimpleDocExtractor.ts.md
+++ b/docs/simple-docs-scraper/services/SimpleDocExtractor.ts.md
@@ -9,7 +9,7 @@
 
  @example
  ```typescript
- const scraper = new SimpleDocsScraper({
+ const scraper = new SimpleDocExtractor({
    baseDir: './src',
    extraction: {
      extractMethod: 'tags',
@@ -40,7 +40,7 @@
 
  Returns the current configuration.
 
- @returns The current SimpleDocsScraper configuration
+ @returns The current SimpleDocExtractor configuration
  
 
 ---

--- a/src/simple-docs-scraper/services/LocalesService.ts
+++ b/src/simple-docs-scraper/services/LocalesService.ts
@@ -1,0 +1,45 @@
+import fs from "fs";
+import path from "path";
+import { ExtractedContent } from "../extractors/DocumentContentExtractor.js";
+
+export type Locales = {
+    updatedAt: string;
+    fileName: string;
+};
+
+export class LocalesService {
+    constructor(private file: string) {}
+
+    static toExtractedContents(locales: Locales): ExtractedContent[] {
+        return [
+            {
+                content: locales.updatedAt,
+                attributes: {},
+                searchAndReplace: "%locales.updatedAt%",
+            },
+            {
+                content: locales.fileName,
+                attributes: {},
+                searchAndReplace: "%locales.fileName%",
+            },
+        ];
+    }
+
+    getLocales() {
+        const fileStat = fs.statSync(this.file);
+        const updatedAt = fileStat.mtime.toISOString();
+        const fileName = path.basename(this.file);
+
+        return {
+            updatedAt,
+            fileName,
+        };
+    }
+
+    getLocalesAsExtractedContents(): ExtractedContent[] {
+        const locales = this.getLocales();
+        return LocalesService.toExtractedContents(locales);
+    }
+
+
+}

--- a/src/simple-docs-scraper/services/SimpleDocExtractor.ts
+++ b/src/simple-docs-scraper/services/SimpleDocExtractor.ts
@@ -43,7 +43,7 @@ export type SimpleDocExtractorResult = {
  *
  * @example
  * ```typescript
- * const scraper = new SimpleDocsScraper({
+ * const scraper = new SimpleDocsExtractor({
  *   baseDir: './src',
  *   extraction: {
  *     extractMethod: 'tags',
@@ -78,7 +78,7 @@ export class SimpleDocExtractor {
    * <method name="getConfig">
    * Returns the current configuration.
    *
-   * @returns The current SimpleDocsScraper configuration
+   * @returns The current SimpleDocExtractor configuration
    * </method>
    */
   getConfig(): SimpleDocExtractorConfig {

--- a/src/tests/Locales.test.ts
+++ b/src/tests/Locales.test.ts
@@ -1,0 +1,44 @@
+import { LocalesService } from "@/simple-docs-scraper/services/LocalesService.js";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import { deleteOutputFiles } from "./helpers/deleteOutputFiles.js";
+import { getOutputPath } from "./helpers/getOutputPath.js";
+
+describe("Locales", () => {
+
+    beforeEach(() => {
+        deleteOutputFiles();
+
+        fs.writeFileSync(getOutputPath("test.txt"), "");
+    });
+
+    describe("getLocales", () => {
+        test("should perform expected behavior", () => {
+            const value = new LocalesService(getOutputPath("test.txt")).getLocales();
+
+            expect(value).toBeDefined();
+            expect(typeof value.updatedAt === 'string').toBe(true);
+            expect(typeof value.fileName === 'string').toBe(true);
+            expect(value.fileName).toBe("test.txt");
+        })
+
+        describe("getLocalesAsExtractedContents", () => {
+            test("should perform expected behavior", () => {
+                const extractedContentArray = new LocalesService(getOutputPath("test.txt")).getLocalesAsExtractedContents();
+
+                const updatedAt = extractedContentArray.find(content => content.searchAndReplace === "%locales.updatedAt%");
+                const fileName = extractedContentArray.find(content => content.searchAndReplace === "%locales.fileName%");
+
+                expect(updatedAt).toBeDefined();
+                expect(fileName).toBeDefined();
+                expect(typeof  updatedAt?.content === 'string').toBe(true);
+                expect(typeof fileName?.content === 'string').toBe(true);
+                expect(updatedAt?.attributes).toEqual({});
+                expect(fileName?.attributes).toEqual({});
+                expect(updatedAt?.searchAndReplace).toBe("%locales.updatedAt%");
+                expect(fileName?.searchAndReplace).toBe("%locales.fileName%");
+            })
+        })
+    });
+
+});

--- a/src/tests/PublishDocs.test.ts
+++ b/src/tests/PublishDocs.test.ts
@@ -50,7 +50,7 @@ describe("Publish Docs", () => {
       expect(outputFiles.length).toBeGreaterThanOrEqual(1);
       expect(outputFiles.some((file) => file.includes("index.md"))).toBe(true);
 
-      const pathToSimpleDocsScraper = path.join(
+      const pathToSimpleDocExtractor = path.join(
         getOutputPath(),
         "docs/simple-docs-scraper/services/SimpleDocExtractor.ts.md",
       );
@@ -59,7 +59,7 @@ describe("Publish Docs", () => {
         "docs/simple-docs-scraper/generators/DocFileGenerator.ts.md",
       );
 
-      expect(fs.existsSync(pathToSimpleDocsScraper)).toBe(true);
+      expect(fs.existsSync(pathToSimpleDocExtractor)).toBe(true);
       expect(fs.existsSync(pathToDocFileGenerator)).toBe(true);
     });
   });

--- a/src/tests/blank.test.ts.template
+++ b/src/tests/blank.test.ts.template
@@ -2,15 +2,15 @@ import { beforeEach, describe, expect, test } from "@jest/globals";
 
 describe("Example Test Suite", () => {
 
-  beforeEach(() => {
-    // Setup code here
-  });
+    beforeEach(() => {
+        // Setup code here
+    });
 
-  describe("Example Feature", () => {
-    test("should perform expected behavior", () => {
-      // Test implementation here
-      const value = 1
-      expect(value).toBe(1)
-    })
-  });
+    describe("Example Feature", () => {
+        test("should perform expected behavior", () => {
+            // Test implementation here
+            const value = 1
+            expect(value).toBe(1)
+        })
+    });
 });


### PR DESCRIPTION
…support

- Update README and documentation to reflect the renaming of SimpleDocsScraper to SimpleDocExtractor.
- Introduce LocalesService for managing locale variables in documentation templates.
- Enhance CodeFileProcessor to include locales in the output.
- Add tests for LocalesService and its integration with SimpleDocExtractor.