### PR TITLE
fix: remove extraction property from SimpleDocExtractorConfig

### DIFF
--- a/src/scripts/publish-docs.ts
+++ b/src/scripts/publish-docs.ts
@@ -25,7 +25,6 @@ import path from "path";
  */
 export const DEFAULT_CONFIG: SimpleDocExtractorConfig = {
   baseDir: process.cwd(),
-  extraction: [],
   generators: {
     index: {
       template: path.join(process.cwd(), "src/templates/index.template.md"),

--- a/src/simple-docs-scraper/processors/CodeFileProcessor.ts
+++ b/src/simple-docs-scraper/processors/CodeFileProcessor.ts
@@ -104,7 +104,7 @@ export class CodeFileProcessor {
     // Apply default text
     injectedContent = contentInjection.applyDefaultText(
       injectedContent,
-      this.config.extraction,
+      this.getDocumentContentExtractorConfig(target),
     );
 
     // Apply formatters
@@ -205,9 +205,6 @@ export class CodeFileProcessor {
   getDocumentContentExtractorConfig(
     target: Target,
   ): DocumentContentExtractorConfig {
-    if (target.extraction) {
-      return target.extraction;
-    }
-    return this.config.extraction;
+      return target.extraction ?? [];
   }
 }

--- a/src/simple-docs-scraper/types/config.ts
+++ b/src/simple-docs-scraper/types/config.ts
@@ -1,4 +1,3 @@
-import { DocumentContentExtractorConfig } from "../extractors/DocumentContentExtractor.js";
 import { DocFileGeneratorConfig } from "../generators/DocFileGenerator.js";
 import { IndexFileGeneratorConfig } from "../generators/IndexFileGenerator.js";
 import { Target } from "../services/SimpleDocExtractor.js";
@@ -14,7 +13,6 @@ export type DocumentationGeneratorConfig = {
 
 export interface SimpleDocExtractorConfig {
   baseDir: string;
-  extraction: DocumentContentExtractorConfig;
   generators?: {
     index?: IndexGeneratorConfig;
     documentation?: DocumentationGeneratorConfig;

--- a/src/tests/Formatter.test.ts
+++ b/src/tests/Formatter.test.ts
@@ -9,14 +9,16 @@ import { SimpleDocExtractorConfig } from "../simple-docs-scraper/types/config.js
 import { deleteOutputFiles } from "./helpers/deleteOutputFiles.js";
 import { getOutputPath } from "./helpers/getOutputPath.js";
 
+
+const extraction = [
+  new TagExtractorPlugin({
+    searchAndReplace: "%content%",
+    tag: "<docs>",
+  }),
+];
+
 const defaultConfig: SimpleDocExtractorConfig = {
   baseDir: process.cwd(),
-  extraction: [
-    new TagExtractorPlugin({
-      searchAndReplace: "%content%",
-      tag: "<docs>",
-    }),
-  ],
   generators: {
     documentation: {
       template: getOutputPath("documentation.template.md"),
@@ -30,6 +32,7 @@ const defaultConfig: SimpleDocExtractorConfig = {
       },
       outDir: getOutputPath("js-files"),
       createIndexFile: false,
+      extraction,
     },
   ],
 };

--- a/src/tests/SimpleDocsScraper.test.ts
+++ b/src/tests/SimpleDocsScraper.test.ts
@@ -15,6 +15,13 @@ const TEMPLATE_CONTENT2 = `Begin.
 %content%
 Finish.`;
 
+const extraction = [
+  new TagExtractorPlugin({
+    searchAndReplace: "%content%",
+    tag: "docs",
+  }),
+];
+
 const jsFilesTarget = {
   globOptions: {
     cwd: path.join(process.cwd(), "src/tests/files/js-files"),
@@ -22,6 +29,7 @@ const jsFilesTarget = {
   },
   outDir: getOutputPath("js-files"),
   createIndexFile: true,
+  extraction,
 };
 
 const twigFilesTarget = {
@@ -31,16 +39,11 @@ const twigFilesTarget = {
   },
   outDir: getOutputPath("twig-files"),
   createIndexFile: true,
+  extraction,
 };
 
 const defaultConfig: SimpleDocExtractorConfig = {
   baseDir: path.join(process.cwd(), "src/tests/files"),
-  extraction: [
-    new TagExtractorPlugin({
-      searchAndReplace: "%content%",
-      tag: "<docs>",
-    }),
-  ],
   generators: {
     index: {
       template: getOutputPath("index.template.md"),
@@ -206,6 +209,7 @@ describe("Example Test Suite", () => {
             },
             outDir: getOutputPath("output-files"),
             createIndexFile: true,
+            extraction,
           },
         ],
       });
@@ -229,6 +233,7 @@ describe("Example Test Suite", () => {
             },
             outDir: getOutputPath("output-files"),
             createIndexFile: true,
+            extraction,
           },
         ],
       });


### PR DESCRIPTION
- Remove the extraction property from the SimpleDocExtractorConfig interface.
- Update the CodeFileProcessor to handle extraction configuration correctly.
- Adjust tests to reflect the changes in the default configuration.