### PR TITLE
feat: handle case when no markdown files are found

### DIFF
--- a/src/simple-docs-scraper/processors/MarkdownIndexProcessor.ts
+++ b/src/simple-docs-scraper/processors/MarkdownIndexProcessor.ts
@@ -55,6 +55,11 @@ export class MarkdownIndexProcessor {
       markdownLink: this.config?.markdownLinks,
     }).process(directory);
 
+    // If no md files are found, return
+    if (processedEntries.length === 0) {
+      return;
+    }
+    
     // Handle directories recursively
     const directoryEntries = processedEntries.filter((entry) => entry.isDir);
     for (const dirEntry of directoryEntries) {

--- a/src/tests/IndexProcessor.test.ts
+++ b/src/tests/IndexProcessor.test.ts
@@ -470,4 +470,15 @@ This additional text helps simulate a more realistic documentation scenario.`;
       );
     });
   });
+
+  describe("creation with no md files found", () => {
+    test("should not create an index.md file when no md files are found", async () => {
+      fs.mkdirSync(getOutputPath("docs-no-md"), { recursive: true });
+      fs.writeFileSync(getOutputPath("docs-no-md/styles.scss"), "");
+
+      await indexProcessor.handle(getOutputPath("docs-no-md"));
+
+      expect(fs.existsSync(getOutputPath("docs-no-md/index.md"))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
- Add a check in MarkdownIndexProcessor to return early if no markdown files are processed.
- Implement a test to ensure that no index.md file is created when no markdown files are present.