### PR TITLE
fix: only generate root index file for root directory (Added recursiv…

### DIFF
--- a/src/simple-docs-scraper/processors/MarkdownIndexProcessor.ts
+++ b/src/simple-docs-scraper/processors/MarkdownIndexProcessor.ts
@@ -7,7 +7,13 @@ import { IndexStructurePreProcessor } from "./IndexStructurePreProcessor.js";
 export type MarkdownIndexProcessorConfig = Omit<
   IndexFileGeneratorConfig,
   "outDir"
->;
+> & {
+  recursive: boolean;
+};
+
+export const DEFAULT_CONFIG: MarkdownIndexProcessorConfig = {
+  recursive: true,
+};
 
 /**
  * <docs>
@@ -31,7 +37,7 @@ export type MarkdownIndexProcessorConfig = Omit<
  * </docs>
  */
 export class MarkdownIndexProcessor {
-  constructor(private config: MarkdownIndexProcessorConfig = {}) {}
+  constructor(private config: MarkdownIndexProcessorConfig = DEFAULT_CONFIG) { }
 
   /**
    * <method name="handle">
@@ -59,17 +65,19 @@ export class MarkdownIndexProcessor {
     if (processedEntries.length === 0) {
       return;
     }
-    
-    // Handle directories recursively
-    const directoryEntries = processedEntries.filter((entry) => entry.isDir);
-    for (const dirEntry of directoryEntries) {
-      await this.handleDirectoryRecusrively(dirEntry.src);
-    }
 
-    // Re-process entries
-    processedEntries = await new IndexStructurePreProcessor({
-      markdownLink: this.config?.markdownLinks,
-    }).process(directory);
+    if (this.config?.recursive) {
+      // Handle directories recursively
+      const directoryEntries = processedEntries.filter((entry) => entry.isDir);
+      for (const dirEntry of directoryEntries) {
+        await this.handleDirectoryRecusrively(dirEntry.src);
+      }
+
+      // Re-process entries
+      processedEntries = await new IndexStructurePreProcessor({
+        markdownLink: this.config?.markdownLinks,
+      }).process(directory);
+    }
 
     // Save the index.md file
     await new IndexFileGenerator({

--- a/src/simple-docs-scraper/services/SimpleDocExtractor.ts
+++ b/src/simple-docs-scraper/services/SimpleDocExtractor.ts
@@ -227,6 +227,7 @@ export class SimpleDocExtractor {
 
     await new MarkdownIndexProcessor({
       ...this.getIndexProcessorConfig(target),
+      recursive: true,
     }).handle(target.outDir);
   }
 
@@ -247,6 +248,7 @@ export class SimpleDocExtractor {
     
     await new MarkdownIndexProcessor({
       ...templateConfig,
+      recursive: false,
     }).handle(baseDir);
   }
 

--- a/src/tests/IndexProcessor.test.ts
+++ b/src/tests/IndexProcessor.test.ts
@@ -237,6 +237,7 @@ describe("Example Test Suite", () => {
       const indexProcessor = new MarkdownIndexProcessor({
         markdownLinks: true,
         templatePath: getOutputPath("templates/index.template.md"),
+        recursive: true,
       });
 
       await indexProcessor.handle(docsPath);
@@ -266,6 +267,7 @@ describe("Example Test Suite", () => {
 
       const indexProcessor = new MarkdownIndexProcessor({
         markdownLinks: true,
+        recursive: true,
       });
       await indexProcessor.handle(docsListDirs);
 
@@ -293,6 +295,7 @@ describe("Example Test Suite", () => {
 
       const indexProcessor = new MarkdownIndexProcessor({
         markdownLinks: true,
+        recursive: true,
       });
 
       await indexProcessor.handle(docsListDirs);
@@ -322,6 +325,7 @@ describe("Example Test Suite", () => {
 
       const indexProcessor = new MarkdownIndexProcessor({
         markdownLinks: true,
+        recursive: true,
       });
 
       await indexProcessor.handle(docsListDirs);
@@ -379,6 +383,7 @@ describe("Example Test Suite", () => {
     test("should create files with a heading", async () => {
       indexProcessor = new MarkdownIndexProcessor({
         filesHeading: "## Files",
+        recursive: true,
       });
 
       fs.mkdirSync(getOutputPath("docs-heading"), { recursive: true });
@@ -398,6 +403,7 @@ describe("Example Test Suite", () => {
     test("should create directories with a heading", async () => {
       indexProcessor = new MarkdownIndexProcessor({
         directoryHeading: "## Folders",
+        recursive: true,
       });
 
       fs.mkdirSync(getOutputPath("docs-heading/a"), { recursive: true });
@@ -417,6 +423,7 @@ describe("Example Test Suite", () => {
       indexProcessor = new MarkdownIndexProcessor({
         directoryHeading: "## Folders",
         filesHeading: "## Files",
+        recursive: true,
       });
 
       fs.mkdirSync(getOutputPath("docs-heading/a"), { recursive: true });
@@ -457,6 +464,7 @@ This additional text helps simulate a more realistic documentation scenario.`;
           addEllipsis: true,
           firstSentenceOnly: false,
         },
+        recursive: true,
       });
       await indexProcessor.handle(getOutputPath("docs-excerpt"));
 

--- a/src/tests/PublishDocs.test.ts
+++ b/src/tests/PublishDocs.test.ts
@@ -137,4 +137,25 @@ describe("Publish Docs", () => {
       expect(rootIndexFileContent).toContain("## Table of Contents");
     });
   });
+
+  describe("uses non-root index template in sub Folders", () => {
+    test("should use the non-root index template in sub folders", async () => {
+      await publishDocs({
+        ...testConfig,
+      });
+
+      const rootIndexFileContent = fs.readFileSync(getOutputPath("docs/index.md"), "utf8");
+  
+      expect(rootIndexFileContent).toContain("# Simple Docs Extractor");
+      expect(rootIndexFileContent).toContain("## Features");
+      expect(rootIndexFileContent).toContain("## Table of Contents");
+
+      const nonRootIndexFileContent = fs.readFileSync(getOutputPath("docs/simple-docs-scraper/index.md"), "utf8");
+
+      expect(nonRootIndexFileContent).not.toContain("# Simple Docs Scraper");
+      expect(nonRootIndexFileContent).not.toContain("## Features");
+      expect(nonRootIndexFileContent).toContain("Table of Contents");
+    });
+
+  });
 });


### PR DESCRIPTION
…e option to MarkdownIndexProcessor)

- Introduce a `recursive` property in `MarkdownIndexProcessorConfig`
- Set default value of `recursive` to true
- Update `MarkdownIndexProcessor` to handle directories recursively based on the `recursive` flag
- Modify tests to include the `recursive` option in various scenarios